### PR TITLE
Feature/todo mail notifications

### DIFF
--- a/app/DoctrineMigrations/Version20170827120244.php
+++ b/app/DoctrineMigrations/Version20170827120244.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Prooph\ProophessorDo\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Prooph\ProophessorDo\Projection\Table;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170827120244 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $todoTable = $schema->getTable(Table::TODO);
+        $todoTable->addColumn('reminded', 'boolean', ['default' => false, 'notnull' => false]);
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $todoTable = $schema->getTable(Table::TODO);
+        $todoTable->dropColumn('reminded');
+    }
+}

--- a/src/AppBundle/EventListener/TodoNotifyListener.php
+++ b/src/AppBundle/EventListener/TodoNotifyListener.php
@@ -49,11 +49,11 @@ final class TodoNotifyListener implements EventSubscriberInterface
         $expiredTodos = $this->todoFinder->findOpenWithPastTheirDeadline();
 
         if (0 === count($expiredTodos)) {
-            $this->logger->info('no expired todos found, exit process');
+            $this->logger->debug('no expired todos found, exit process');
             return;
         }
 
-        $this->logger->info(
+        $this->logger->debug(
             sprintf(
                 '%s expired todos found, start dispatching commands',
                 count($expiredTodos)
@@ -63,7 +63,7 @@ final class TodoNotifyListener implements EventSubscriberInterface
         /** @var \stdClass $todo */
         foreach ($expiredTodos as $todo) {
             if (isset($todo->id)) {
-                $this->logger->info(
+                $this->logger->debug(
                     sprintf(
                         'dispatching the MarkTodoAsExpired command for todo %s with topic %s',
                         $todo->id,

--- a/src/AppBundle/EventListener/TodoNotifyListener.php
+++ b/src/AppBundle/EventListener/TodoNotifyListener.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Prooph\AppBundle\EventListener;
+
+use Prooph\ProophessorDo\Model\Todo\Command\MarkTodoAsExpired;
+use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+use Prooph\ServiceBus\CommandBus;
+use Prooph\ServiceBus\Exception\CommandDispatchException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class TodoNotifyListener implements EventSubscriberInterface
+{
+    /**
+     * @var CommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var TodoFinder
+     */
+    private $todoFinder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * TodoNotifyListener constructor.
+     * @param CommandBus $commandBus
+     * @param TodoFinder $todoFinder
+     * @param LoggerInterface $logger
+     */
+    public function __construct(CommandBus $commandBus, TodoFinder $todoFinder, LoggerInterface $logger)
+    {
+        $this->commandBus = $commandBus;
+        $this->todoFinder = $todoFinder;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param PostResponseEvent $event
+     */
+    public function onTerminateSendExpiredNotifications(PostResponseEvent $event)
+    {
+        $expiredTodos = $this->todoFinder->findOpenWithPastTheirDeadline();
+
+        if (0 === count($expiredTodos)) {
+            $this->logger->info('no expired todos found, exit process');
+            return;
+        }
+
+        $this->logger->info(
+            sprintf(
+                '%s expired todos found, start dispatching commands',
+                count($expiredTodos)
+            )
+        );
+
+        /** @var \stdClass $todo */
+        foreach ($expiredTodos as $todo) {
+            if (isset($todo->id)) {
+                $this->logger->info(
+                    sprintf(
+                        'dispatching the MarkTodoAsExpired command for todo %s with topic %s',
+                        $todo->id,
+                        $todo->text
+                    )
+                );
+
+                try {
+                    $this->commandBus->dispatch(
+                        MarkTodoAsExpired::forTodo($todo->id)
+                    );
+                } catch (CommandDispatchException $exception) {
+                    $this->logger->error($exception->getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * @{@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::TERMINATE => 'onTerminateSendExpiredNotifications'
+        ];
+    }
+}

--- a/src/AppBundle/Resources/config/service_bus.yml
+++ b/src/AppBundle/Resources/config/service_bus.yml
@@ -52,7 +52,7 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsExpired':
             - 'proophdo.todo_projection.todo_projector'
             - 'proophdo.todo_projection.user_projector'
-            - 'proophdo.process_manager.send_todo_deadline_mailer'
+            - 'proophdo.send_todo_deadline_expired_mail_subscriber'
 
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasUnmarkedAsExpired':
             - 'proophdo.todo_projection.todo_projector'

--- a/src/AppBundle/Resources/config/service_bus.yml
+++ b/src/AppBundle/Resources/config/service_bus.yml
@@ -52,7 +52,7 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsExpired':
             - 'proophdo.todo_projection.todo_projector'
             - 'proophdo.todo_projection.user_projector'
-            - 'Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailSubscriber'
+            - 'proophdo.process_manager.send_todo_deadline_mailer'
 
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasUnmarkedAsExpired':
             - 'proophdo.todo_projection.todo_projector'

--- a/src/AppBundle/Resources/config/service_bus.yml
+++ b/src/AppBundle/Resources/config/service_bus.yml
@@ -47,7 +47,7 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded':
             - 'proophdo.todo_projection.todo_projector'
             - 'proophdo.todo_projection.todo_reminder_projector'
-            - 'Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailSubscriber'
+            - 'proophdo.send_todo_reminder_mail_subscriber'
 
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsExpired':
             - 'proophdo.todo_projection.todo_projector'

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -65,3 +65,7 @@ services:
         arguments: ['@prooph_service_bus.todo_command_bus', '@proophdo.todo_projection.todo_finder','@logger']
         tags:
              - { name: kernel.event_subscriber }
+
+    proophdo.process_manager.send_todo_deadline_mailer:
+        class: Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailSubscriber
+        arguments: ['@proophdo.todo_projection.user_finder','@proophdo.todo_projection.todo_finder','@mailer','@logger']

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -59,3 +59,9 @@ services:
         class:        Prooph\AppBundle\Twig\RiotTag
         tags:
              - { name: 'twig.extension' }
+
+    proophdo.todo_notify_event_listener:
+        class: Prooph\AppBundle\EventListener\TodoNotifyListener
+        arguments: ['@prooph_service_bus.todo_command_bus', '@proophdo.todo_projection.todo_finder','@logger']
+        tags:
+             - { name: kernel.event_subscriber }

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -59,6 +59,10 @@ services:
         class: Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailSubscriber
         arguments: ['@proophdo.todo_projection.user_finder','@proophdo.todo_projection.todo_finder', '@mailer', '@logger' ]
 
+    proophdo.send_todo_reminder_mail_subscriber:
+        class: Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailSubscriber
+        arguments: ['@proophdo.todo_projection.user_finder','@proophdo.todo_projection.todo_finder', '@mailer', '@logger' ]
+
     proophdo.twig.extension.riot_tag:
         class:        Prooph\AppBundle\Twig\RiotTag
         tags:

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -55,6 +55,10 @@ services:
         class: Prooph\ProophessorDo\Model\Todo\Handler\RemindTodoAssigneeHandler
         arguments: ['@todo_list']
 
+    proophdo.send_todo_deadline_expired_mail_subscriber:
+        class: Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailSubscriber
+        arguments: ['@proophdo.todo_projection.user_finder','@proophdo.todo_projection.todo_finder', '@mailer', '@logger' ]
+
     proophdo.twig.extension.riot_tag:
         class:        Prooph\AppBundle\Twig\RiotTag
         tags:
@@ -65,7 +69,3 @@ services:
         arguments: ['@prooph_service_bus.todo_command_bus', '@proophdo.todo_projection.todo_finder','@logger']
         tags:
              - { name: kernel.event_subscriber }
-
-    proophdo.process_manager.send_todo_deadline_mailer:
-        class: Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailSubscriber
-        arguments: ['@proophdo.todo_projection.user_finder','@proophdo.todo_projection.todo_finder','@mailer','@logger']

--- a/src/ProophessorDo/Model/Todo/Todo.php
+++ b/src/ProophessorDo/Model/Todo/Todo.php
@@ -343,6 +343,7 @@ final class Todo extends AggregateRoot
     protected function whenReminderWasAddedToTodo(ReminderWasAddedToTodo $event)
     {
         $this->reminder = $event->reminder();
+        $this->reminded = false;
     }
 
     /**
@@ -352,6 +353,7 @@ final class Todo extends AggregateRoot
     protected function whenTodoAssigneeWasReminded(TodoAssigneeWasReminded $event)
     {
         $this->reminder = $event->reminder();
+        $this->reminded = true;
     }
 
     /**

--- a/src/ProophessorDo/ProcessManager/SendTodoDeadlineExpiredMailSubscriber.php
+++ b/src/ProophessorDo/ProcessManager/SendTodoDeadlineExpiredMailSubscriber.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Prooph\ProophessorDo\ProcessManager;
 
 use Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsExpired;
 use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
 use Prooph\ProophessorDo\Projection\User\UserFinder;
+use Psr\Log\LoggerInterface;
 use Zend\Mail\Message;
 use Zend\Mail\Transport\TransportInterface;
 
@@ -31,19 +33,28 @@ final class SendTodoDeadlineExpiredMailSubscriber
     private $mailer;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * SendTodoDeadlineExpiredMailSubscriber constructor.
      * @param UserFinder $userFinder
      * @param TodoFinder $todoFinder
      * @param TransportInterface $mailer
+     * @param LoggerInterface $logger
      */
     public function __construct(
         UserFinder $userFinder,
         TodoFinder $todoFinder,
-        TransportInterface $mailer
-    ) {
+        TransportInterface $mailer,
+        LoggerInterface $logger
+    )
+    {
         $this->userFinder = $userFinder;
         $this->todoFinder = $todoFinder;
         $this->mailer = $mailer;
+        $this->logger = $logger;
     }
 
     /**
@@ -70,5 +81,6 @@ final class SendTodoDeadlineExpiredMailSubscriber
         $mail->setSubject('Proophessor-do Todo expired');
 
         $this->mailer->send($mail);
+        $this->logger->info('mail was sent to ' . $user->email);
     }
 }

--- a/src/ProophessorDo/ProcessManager/SendTodoDeadlineExpiredMailSubscriber.php
+++ b/src/ProophessorDo/ProcessManager/SendTodoDeadlineExpiredMailSubscriber.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
  * Class SendTodoDeadlineExpiredMailSubscriber
  *
  * @package Prooph\ProophessorDo\App\Mail
- * @author Michał Żukowski <michal@durooil.com
+ * @author Michał Żukowski <michal@durooil.com>, Patrick Blom <info@patrick-blom.de>
  */
 final class SendTodoDeadlineExpiredMailSubscriber
 {

--- a/src/ProophessorDo/Projection/Todo/TodoFinder.php
+++ b/src/ProophessorDo/Projection/Todo/TodoFinder.php
@@ -8,6 +8,7 @@
  *
  * Date: 5/4/15 - 8:47 PM
  */
+
 namespace Prooph\ProophessorDo\Projection\Todo;
 
 use Doctrine\DBAL\Connection;
@@ -85,7 +86,13 @@ class TodoFinder
     {
         $stmt = $this
             ->connection
-            ->prepare(sprintf('SELECT * FROM %s where reminder < NOW() AND reminded = 0', Table::TODO));
+            ->prepare(
+                sprintf(
+                    "SELECT * FROM %s where reminder < '%s' AND reminded = 0",
+                    Table::TODO,
+                    (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTime::ATOM)
+                )
+            );
         $stmt->execute();
 
         return $stmt->fetchAll();
@@ -98,8 +105,9 @@ class TodoFinder
     {
         return $this->connection->fetchAll(
             sprintf(
-                "SELECT * FROM %s WHERE status = :status AND deadline < CONVERT_TZ(NOW(), @@session.time_zone, '+00:00')",
-                Table::TODO
+                "SELECT * FROM %s WHERE status = :status AND deadline < '%s'",
+                Table::TODO,
+                (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTime::ATOM)
             ),
             ['status' => TodoStatus::OPEN]
         );

--- a/src/ProophessorDo/Projection/Todo/TodoProjector.php
+++ b/src/ProophessorDo/Projection/Todo/TodoProjector.php
@@ -13,6 +13,7 @@ namespace Prooph\ProophessorDo\Projection\Todo;
 use Doctrine\DBAL\Connection;
 use Prooph\ProophessorDo\Model\Todo\Event\DeadlineWasAddedToTodo;
 use Prooph\ProophessorDo\Model\Todo\Event\ReminderWasAddedToTodo;
+use Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded;
 use Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsDone;
 use Prooph\ProophessorDo\Model\Todo\Event\TodoWasMarkedAsExpired;
 use Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted;
@@ -114,6 +115,7 @@ final class TodoProjector
             Table::TODO,
             [
                 'reminder' => $event->reminder()->toString(),
+                'reminded' => false
             ],
             [
                 'id' => $event->todoId()->toString(),
@@ -144,6 +146,21 @@ final class TodoProjector
         $this->connection->update(Table::TODO,
             [
                 'status' => $event->newStatus()->toString()
+            ],
+            [
+                'id' => $event->todoId()->toString()
+            ]
+        );
+    }
+
+    /**
+     * @param TodoAssigneeWasReminded $event
+     */
+    public function onTodoAssigneeWasReminded(TodoAssigneeWasReminded $event)
+    {
+        $this->connection->update(Table::TODO,
+            [
+                'reminded' => true
             ],
             [
                 'id' => $event->todoId()->toString()


### PR DESCRIPTION
Hey everybody,
today i work since about two or three weeks with prooph and i'm still impressed about the concept and the flexibility of the components. I'm also really looking forward to use the prooph components in my next project. 

But anyways, to become a little bit more familiar with prooph i started to work on the open tasks for the expire and reminder mail notification. This is what i ended up with. 

In short terms, i added a Symfony EventListener on the kernel onTerminate event which asks the read model if there is anything that has to be notified. If there is something, the required command is dispatched to the command bus. Further i replaced the zend mailer with the one provided by Symfony. 

I know it's not the fanciest way solve the problem, but it fulfills the requirements and does the job without any blown hipstar background worker ^^

So plz, let me know what you're thinking about :)
 