### PR TITLE
Fixing ProcessManager service declaration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -109,10 +109,10 @@ services:
         class: Prooph\ProophessorDo\Infrastructure\Service\ChecksUniqueUsersEmailAddressFromReadModel
 
     Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailProcessManager:
-        class: Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailProcessManager
+        public: true
 
     Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailProcessManager:
-        class: Prooph\ProophessorDo\ProcessManager\SendTodoDeadlineExpiredMailProcessManager
+        public: true
 
     proophdo.todo_projection.user_finder:
         class: Prooph\ProophessorDo\Projection\User\UserFinder

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,12 +41,10 @@ services:
         tags: ['controller.service_arguments']
 
     App\Controller\UserTodoFormController:
-        class: App\Controller\UserTodoFormController
         arguments: ['@templating', '@proophdo.todo_projection.user_finder']
         tags: ['controller.service_arguments']
 
     App\Controller\ApiCommandController:
-        class: App\Controller\ApiCommandController
         arguments: ['@prooph_service_bus.todo_command_bus', '@prooph_service_bus.message_factory']
         tags: ['controller.service_arguments']
 


### PR DESCRIPTION
The ProcessManager Services have to be public. 
`
Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailProcessManager:
        public: true
`

Otherwise the configuration below does not work. Would be interpreted as string because no service with this name is found.

`
        routes:
          'Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded':
            - 'Prooph\ProophessorDo\ProcessManager\SendTodoReminderMailProcessManager'
`