### PR TITLE
Add missing projection services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -126,11 +126,14 @@ services:
         class: Prooph\ProophessorDo\Projection\Todo\TodoReminderFinder
         arguments: ['@doctrine.dbal.default_connection']
 
+    Prooph\ProophessorDo\Projection\User\UserProjection: ~
     Prooph\ProophessorDo\Projection\User\UserReadModel:
         arguments: ['@doctrine.dbal.default_connection']
 
+    Prooph\ProophessorDo\Projection\Todo\TodoProjection: ~
     Prooph\ProophessorDo\Projection\Todo\TodoReadModel:
         arguments: ['@doctrine.dbal.default_connection']
 
+    Prooph\ProophessorDo\Projection\Todo\TodoReminderProjection: ~
     Prooph\ProophessorDo\Projection\Todo\TodoReminderReadModel:
         arguments: ['@doctrine.dbal.default_connection']


### PR DESCRIPTION
Services are referenced in [prooph_event_store.yaml](https://github.com/prooph/proophessor-do-symfony/blob/637941735e4c290156dc876b9d56b49146065e64/config/packages/prooph_event_store.yaml#L20) but not defined.